### PR TITLE
feat: Add web support

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -30,11 +30,8 @@ public class CapacitorFirebaseDynamicLinks: CAPPlugin {
         buildITunesParameters(call: call, builder: builder)
         buildSocialMetaParameters(call: call, builder: builder)
 
-        guard let longUrl = builder.url else { return }
-        print("The long URL is: \(longUrl.absoluteString)")
-
         guard let longDynamicLink = builder.url else { return }
-        print("The long URL is: \(longDynamicLink)")
+        print("The long URL is: \(longDynamicLink.absoluteString)")
 
         call.resolve([
             "value": longDynamicLink,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantrist/capacitor-firebase-dynamic-links",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Capacitor Plugin for Firebase Dynamic Links",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,6 +23,7 @@ export interface LinkConfig {
   socialMeta?: SocialMetaTagParameters;
   googleAnalytics?: GoogleAnalyticsParameters;
   iTunesConnectAnalytics?: ItunesConnectAnalyticsParameters;
+  webApiKey?: string;
 }
 
 export interface AndroidParameters {

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,14 +1,193 @@
-import { WebPlugin } from '@capacitor/core';
+import { WebPlugin } from "@capacitor/core";
 
-import { CapacitorFirebaseDynamicLinksPlugin, LinkConfig } from './definitions';
+import { CapacitorFirebaseDynamicLinksPlugin, LinkConfig } from "./definitions";
 
-export class CapacitorFirebaseDynamicLinksWeb extends WebPlugin implements CapacitorFirebaseDynamicLinksPlugin {
-  createDynamicLink(_: LinkConfig): Promise<{ value: string; }> {
-    throw new Error('Method not implemented.');
+interface DynamicLinkInfo {
+  longDynamicLink: string;
+  suffix?: {
+    option: "SHORT" | "UNGUESSABLE";
+  };
+}
+
+export class CapacitorFirebaseDynamicLinksWeb
+  extends WebPlugin
+  implements CapacitorFirebaseDynamicLinksPlugin
+{
+  createDynamicLink(linkConfig: LinkConfig): Promise<{ value: string }> {
+    const dynamicLink = new URL(linkConfig.domainUriPrefix);
+
+    dynamicLink.searchParams.append("link", linkConfig.uri);
+
+    if (linkConfig.androidParameters) {
+      dynamicLink.searchParams.append(
+        "apn",
+        linkConfig.androidParameters.packageName
+      );
+
+      if (linkConfig.androidParameters.fallbackUrl) {
+        dynamicLink.searchParams.append(
+          "afl",
+          linkConfig.androidParameters.fallbackUrl
+        );
+      }
+
+      if (linkConfig.androidParameters.minimumVersion) {
+        dynamicLink.searchParams.append(
+          "amv",
+          linkConfig.androidParameters.minimumVersion.toString()
+        );
+      }
+    }
+
+    if (linkConfig.iosParameters) {
+      dynamicLink.searchParams.append("ibi", linkConfig.iosParameters.bundleId);
+
+      if (linkConfig.iosParameters.fallbackUrl) {
+        dynamicLink.searchParams.append(
+          "ifl",
+          linkConfig.iosParameters.fallbackUrl
+        );
+      }
+
+      if (linkConfig.iosParameters.customScheme) {
+        dynamicLink.searchParams.append(
+          "ius",
+          linkConfig.iosParameters.customScheme
+        );
+      }
+
+      if (linkConfig.iosParameters.ipadFallbackUrl) {
+        dynamicLink.searchParams.append(
+          "ipfl",
+          linkConfig.iosParameters.ipadFallbackUrl
+        );
+      }
+
+      if (linkConfig.iosParameters.ipadBundleId) {
+        dynamicLink.searchParams.append(
+          "ipbi",
+          linkConfig.iosParameters.ipadBundleId
+        );
+      }
+
+      if (linkConfig.iosParameters.appStoreId) {
+        dynamicLink.searchParams.append(
+          "isi",
+          linkConfig.iosParameters.appStoreId
+        );
+      }
+
+      if (linkConfig.iosParameters.minimumVersion) {
+        dynamicLink.searchParams.append(
+          "imv",
+          linkConfig.iosParameters.minimumVersion
+        );
+      }
+    }
+
+    if (linkConfig.socialMeta) {
+      if (linkConfig.socialMeta.title) {
+        dynamicLink.searchParams.append("st", linkConfig.socialMeta.title);
+      }
+
+      if (linkConfig.socialMeta.description) {
+        dynamicLink.searchParams.append(
+          "sd",
+          linkConfig.socialMeta.description
+        );
+      }
+
+      if (linkConfig.socialMeta.imageUrl) {
+        dynamicLink.searchParams.append("si", linkConfig.socialMeta.imageUrl);
+      }
+    }
+
+    if (linkConfig.googleAnalytics) {
+      if (linkConfig.googleAnalytics.source) {
+        dynamicLink.searchParams.append(
+          "utm_source",
+          linkConfig.googleAnalytics.source
+        );
+      }
+
+      if (linkConfig.googleAnalytics.medium) {
+        dynamicLink.searchParams.append(
+          "utm_medium",
+          linkConfig.googleAnalytics.medium
+        );
+      }
+
+      if (linkConfig.googleAnalytics.campaign) {
+        dynamicLink.searchParams.append(
+          "utm_campaign",
+          linkConfig.googleAnalytics.campaign
+        );
+      }
+
+      if (linkConfig.googleAnalytics.term) {
+        dynamicLink.searchParams.append(
+          "utm_term",
+          linkConfig.googleAnalytics.term
+        );
+      }
+
+      if (linkConfig.googleAnalytics.content) {
+        dynamicLink.searchParams.append(
+          "utm_content",
+          linkConfig.googleAnalytics.content
+        );
+      }
+    }
+
+    if (linkConfig.iTunesConnectAnalytics) {
+      if (linkConfig.iTunesConnectAnalytics.affiliateToken) {
+        dynamicLink.searchParams.append(
+          "at",
+          linkConfig.iTunesConnectAnalytics.affiliateToken
+        );
+      }
+
+      if (linkConfig.iTunesConnectAnalytics.campaignToken) {
+        dynamicLink.searchParams.append(
+          "ct",
+          linkConfig.iTunesConnectAnalytics.campaignToken
+        );
+      }
+
+      if (linkConfig.iTunesConnectAnalytics.providerToken) {
+        dynamicLink.searchParams.append(
+          "pt",
+          linkConfig.iTunesConnectAnalytics.providerToken
+        );
+      }
+    }
+
+    return Promise.resolve({ value: dynamicLink.toString() });
   }
 
-  createDynamicShortLink(_: LinkConfig): Promise<{ value: string; }> {
-    throw new Error('Method not implemented.');
+  createDynamicShortLink(linkConfig: LinkConfig): Promise<{ value: string }> {
+    if (!linkConfig.webApiKey) {
+      throw new Error("Unable to get firebase api key from default app");
+    }
+
+    return this.createDynamicLink(linkConfig)
+      .then((result) => ({
+        longDynamicLink: result.value,
+      }))
+      .then((dynamicLinkInfo: DynamicLinkInfo) =>
+        fetch(
+          `https://firebasedynamiclinks.googleapis.com/v1/shortLinks?key=${linkConfig.webApiKey}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(dynamicLinkInfo),
+          }
+        )
+      )
+      .then((response) => response.json())
+      .then((data) => ({
+        value: data.shortLink,
+      }));
   }
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -14,7 +14,7 @@ export class CapacitorFirebaseDynamicLinksWeb
   implements CapacitorFirebaseDynamicLinksPlugin
 {
   createDynamicLink(linkConfig: LinkConfig): Promise<{ value: string }> {
-    const dynamicLink = new URL(linkConfig.domainUriPrefix);
+    const dynamicLink = new URL(`${linkConfig.domainUriPrefix}/`);
 
     dynamicLink.searchParams.append("link", linkConfig.uri);
 


### PR DESCRIPTION
This PR introduces web support for generating firebase dynamic links.

For generating long links, this is simply done by using the default JavaScript URL API and setting all the respective URL parameters.

For generating short links, the dynamic links REST API is used. This requires to pass the firebase web api key as query parameter. To reflect this, an additional parameter was added to the LinkConfig that takes the firebase web api key.

In code, this could be retrieved by using `getApp().options.apiKey`.

*Introduces version bump to 1.1.0*